### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## 0.1.2 - 2026-01-06
 ## 0.1.1 - 2025-06-18
 ### Other
 - New cliff template

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chicago_project_zero_fatalities_parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chicago_project_zero_fatalities_parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Diego Enriquez-Serrano <diego@diegoenriquezserrano.dev>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `chicago_project_zero_fatalities_parser`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).